### PR TITLE
Fix last matches to show only past fixtures

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,8 +76,9 @@ def get_h2h_history(home_team, away_team, n=5):
     return history
 
 def get_team_last_matches(team, n=5):
-    home_matches = df[df['home_team'] == team].sort_values('date', ascending=False).head(n)
-    away_matches = df[df['away_team'] == team].sort_values('date', ascending=False).head(n)
+    current_date = datetime.now()
+    home_matches = df[(df['home_team'] == team) & (df['date'] < current_date)].sort_values('date', ascending=False).head(n)
+    away_matches = df[(df['away_team'] == team) & (df['date'] < current_date)].sort_values('date', ascending=False).head(n)
     
     all_matches = pd.concat([home_matches, away_matches]).sort_values('date', ascending=False).head(n)
     


### PR DESCRIPTION
Fixes #2

Fixed the home_matches and away_matches variable in the get_team_last_matches method to ensure that the past 5 fixtures are shown and not the next 5 fixtures. 

Added a condition to check for matches with dates that are smaller than the current date.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stevenmcsorley/football_prediction/pull/3?shareId=f79af0b9-ba5f-4390-8b3f-b9396e78a5a2).